### PR TITLE
some fixes

### DIFF
--- a/src/main/java/org/hampelratte/svdrp/responses/highlevel/DVBChannel.java
+++ b/src/main/java/org/hampelratte/svdrp/responses/highlevel/DVBChannel.java
@@ -278,7 +278,12 @@ public class DVBChannel extends BroadcastChannel {
     }
 
     public String getChannelID() {
-        return getSource()+"-"+getNID()+"-"+getTID()+"-"+getSID()+"-"+getRID();
+    	StringBuffer sb = new StringBuffer();
+    	sb.append(getSource()).append("-").append(getNID()).append("-").append(getTID()).append("-").append(getSID());
+    	if(getRID() != 0){
+            sb.append("-").append(getRID());
+    	}
+    	return sb.toString();
     }
     
     @Override
@@ -357,14 +362,14 @@ public class DVBChannel extends BroadcastChannel {
         }
         
         // validate codeRateHP
-        validValues = new int[] {-1, 0, 12, 23, 34, 45, 56, 67, 78, 89, AUTOMATIC};
+        validValues = new int[] {-1, 0, 12, 23, 34, 45, 56, 67, 78, 89, 910, AUTOMATIC};
         valid = validateArray(validValues, codeRateHP);
         if(!valid) {
             throwIllegalArgumentException("Code rate HP", codeRateHP, validValues);
         }
         
         // validate codeRateLP
-        validValues = new int[] {-1, 0, 12, 23, 34, 45, 56, 67, 78, 89, AUTOMATIC};
+        validValues = new int[] {-1, 0, 12, 23, 34, 45, 56, 67, 78, 89, 910, AUTOMATIC};
         valid = validateArray(validValues, codeRateLP);
         if(!valid) {
             throwIllegalArgumentException("Code rate LP", codeRateLP, validValues);


### PR DESCRIPTION
- getChannelID has now no RID at the and if it is =0. The reason is
  that LSTE returns the list of epgs without RID if it is 0. So the match
  of the getChanneldID of a DVBChannel and an EPGEntry was not possible.
-  accept 910 as 
  C (0, 12, 13, 14, 23, 25, 34, 35, 45, 56, 67, 78, 89, 910) Code rate high priority
  D (0, 12, 13, 14, 23, 25, 34, 35, 45, 56, 67, 78, 89, 910) Code rate low priority
